### PR TITLE
Add possibility to send header

### DIFF
--- a/lib/likeno/entity.rb
+++ b/lib/likeno/entity.rb
@@ -100,6 +100,15 @@ module Likeno
       new(response[entity_name], true)
     end
 
+    def self.all(headers = {}, params = {})
+      action = ''
+      method = :get
+      prefix = ''
+
+      response = request(action, params, method, prefix, headers)
+      response.map { |record| new(record, true) }
+    end
+
     def destroy
       without_request_error? do
         response = self.class.request(destroy_action, destroy_params, :delete, destroy_prefix)
@@ -171,4 +180,3 @@ module Likeno
     include HashConverters
   end
 end
-

--- a/lib/likeno/entity.rb
+++ b/lib/likeno/entity.rb
@@ -95,8 +95,8 @@ module Likeno
       request(exists_action, id_params(id), :get)['exists']
     end
 
-    def self.find(id)
-      response = request(find_action, id_params(id), :get)
+    def self.find(id, prefix = '', headers = {})
+      response = request(find_action, id_params(id), :get, prefix, headers)
       new(response[entity_name], true)
     end
 

--- a/lib/likeno/request_methods.rb
+++ b/lib/likeno/request_methods.rb
@@ -19,7 +19,7 @@ require 'likeno/errors'
 
 module Likeno
   module RequestMethods
-    def request(action, params = {}, method = :post, prefix = '')
+    def request(action, params = {}, method = :post, prefix = '', headers = {})
       response = client.send(method) do |request|
         url = "/#{endpoint}/#{action}".gsub(':id', params[:id].to_s)
         url = "/#{prefix}#{url}" unless prefix.empty?
@@ -27,6 +27,8 @@ module Likeno
         request.body = params unless method == :get || params.empty?
         request.options.timeout = 300
         request.options.open_timeout = 300
+
+        headers.each { |(key, value)| request.headers[key] = value }
       end
 
       if response.success?

--- a/spec/likeno/entity_spec.rb
+++ b/spec/likeno/entity_spec.rb
@@ -226,6 +226,7 @@ describe Likeno::Entity do
         expect(subject.class.find(42).id).to eq(42)
       end
     end
+
     context 'passing a prefix and a header' do
       let(:header) { { locale: 'pt_br' } }
 
@@ -241,6 +242,46 @@ describe Likeno::Entity do
       end
     end
   end
+
+  describe 'all' do
+    let(:action) { '' }
+    let(:params) { {} }
+    let(:prefix) { '' }
+    let(:headers) { {} }
+
+    context 'without records on the other side' do
+      before :each do
+        subject.class.expects(:request).with('', {}, :get, '', {}).returns([])
+      end
+
+      it 'is expected to return an empty array' do
+        expect(subject.class.all).to eq([])
+      end
+    end
+    context 'with records on the other side' do
+      before :each do
+        subject.class.expects(:request).with(action, params, :get, prefix, headers)
+          .returns([{ id: 1 }, { id: 2 }])
+      end
+
+      it 'is expected to return an array of entities' do
+        expect(subject.class.all.map(&:id)).to eq([1, 2])
+      end
+    end
+
+    context 'when passing params and headers' do
+      let(:headers) { { locale: 'pt_br' } }
+      let(:params) { { content: nil } }
+
+      before :each do
+        subject.class.expects(:request).with(action, params, :get, prefix, headers)
+          .returns([{ id: 1 }, { id: 2 }])
+      end
+
+      it 'is expected to send the params' do
+        expect(subject.class.all(headers, params).map(&:id)).to eq([1, 2])
+      end
+    end
   end
 
   describe 'destroy' do

--- a/spec/likeno/entity_spec.rb
+++ b/spec/likeno/entity_spec.rb
@@ -201,9 +201,12 @@ describe Likeno::Entity do
   end
 
   describe 'find' do
+    let(:prefix) { '' }
+    let(:header) { {} }
+
     context 'with an inexistent id' do
       before :each do
-        subject.class.expects(:request).at_least_once.with(':id', has_entry(id: 0), :get)
+        subject.class.expects(:request).at_least_once.with(':id', has_entry(id: 0), :get, prefix, header)
           .raises(Likeno::Errors::RecordNotFound)
       end
 
@@ -215,7 +218,7 @@ describe Likeno::Entity do
     context 'with an existent id' do
       before :each do
         subject.class.expects(:entity_name).at_least_once.returns('entity')
-        subject.class.expects(:request).with(':id', has_entry(id: 42), :get)
+        subject.class.expects(:request).with(':id', has_entry(id: 42), :get, prefix, header)
           .returns('entity' => { 'id' => 42 })
       end
 
@@ -223,6 +226,21 @@ describe Likeno::Entity do
         expect(subject.class.find(42).id).to eq(42)
       end
     end
+    context 'passing a prefix and a header' do
+      let(:header) { { locale: 'pt_br' } }
+
+      before :each do
+        subject.class.expects(:entity_name).at_least_once.returns('entity')
+        subject.class.expects(:request)
+          .with(':id', has_entry(id: 42), :get, prefix, header)
+          .returns('entity' => { 'id' => 42 })
+      end
+
+      it 'is expected to return an empty model' do
+        expect(subject.class.find(42, prefix, header).id).to eq(42)
+      end
+    end
+  end
   end
 
   describe 'destroy' do

--- a/spec/likeno/request_methods_spec.rb
+++ b/spec/likeno/request_methods_spec.rb
@@ -119,6 +119,20 @@ describe 'RequestMethods' do
           expect(response).to eq(exists_response)
         end
       end
+
+      context 'with a header' do
+        it 'is expected to make the request with the header included' do
+          # stub.get receives arguments: path, headers, block
+          # The block should be a Array [status, headers, body]
+          prefix = '' # without a prefix
+          faraday_stubs.get('/entities/1') { [200, {}, exists_response, 'asdf'] }
+          response = TestRequester.request(
+            ':id', { id: 1 }, :get, prefix, locale: 'pt_br'
+          )
+
+          expect(response).to eq(exists_response)
+        end
+      end
     end
 
     context 'when the record was not found' do


### PR DESCRIPTION
### Changelog

930b2a3 \* Add method `all` to entity
e5e0603 \* Add possibility to send header in request
### Motivation

Today we cannot send a header in a given request because likeno doesn't give this possibility. Also, we cannot get in the index route from a resource all the records. Here were added this possibility.
