### PR TITLE
Add possibility to send header in request

### DIFF
--- a/lib/likeno/request_methods.rb
+++ b/lib/likeno/request_methods.rb
@@ -19,7 +19,7 @@ require 'likeno/errors'
 
 module Likeno
   module RequestMethods
-    def request(action, params = {}, method = :post, prefix = '')
+    def request(action, params = {}, method = :post, prefix = '', headers = {})
       response = client.send(method) do |request|
         url = "/#{endpoint}/#{action}".gsub(':id', params[:id].to_s)
         url = "/#{prefix}#{url}" unless prefix.empty?
@@ -27,6 +27,8 @@ module Likeno
         request.body = params unless method == :get || params.empty?
         request.options.timeout = 300
         request.options.open_timeout = 300
+
+        headers.each { |(key, value)| request.headers[key] = value }
       end
 
       if response.success?

--- a/spec/likeno/request_methods_spec.rb
+++ b/spec/likeno/request_methods_spec.rb
@@ -119,6 +119,20 @@ describe 'RequestMethods' do
           expect(response).to eq(exists_response)
         end
       end
+
+      context 'with a header' do
+        it 'is expected to make the request with the header included' do
+          # stub.get receives arguments: path, headers, block
+          # The block should be a Array [status, headers, body]
+          prefix = '' # without a prefix
+          faraday_stubs.get('/entities/1', locale: 'pt-br') { [200, {}, exists_response] }
+          response = TestRequester.request(
+            ':id', { id: 1 }, :get, prefix, locale: 'pt-br'
+          )
+
+          expect(response).to eq(exists_response)
+        end
+      end
     end
 
     context 'when the record was not found' do


### PR DESCRIPTION
The headers are useful when you need to send authentication tokens to
external apps for example.

This commit is slightly different from the original one:
e5e0603ae7a35d6213e3fced1c864186e71918aa

The modifications to the `find` method got removed.

Signed off by: Rafael Reggiani Manzo rr.manzo@protonmail.com
Signed off by: Diego Araújo diegoamc@protonmail.ch
