### PR TITLE
Header for crud

### DIFF
--- a/lib/likeno/entity.rb
+++ b/lib/likeno/entity.rb
@@ -54,7 +54,7 @@ module Likeno
         update
       else
         without_request_error? do
-          response = self.class.request(save_action, save_params, :post, save_prefix)
+          response = self.class.request(save_action, save_params, :post, save_prefix, save_headers)
 
           self.id = response[instance_entity_name]["id"]
           self.created_at = response[instance_entity_name]["created_at"] unless response[instance_entity_name]["created_at"].nil?
@@ -78,7 +78,7 @@ module Likeno
     def update(attributes = {})
       attributes.each { |field, value| send("#{field}=", value) if self.class.valid?(field) }
       without_request_error? do
-        self.class.request(update_action, update_params, :put, update_prefix)
+        self.class.request(update_action, update_params, :put, update_prefix, update_headers)
       end
     end
 
@@ -102,7 +102,7 @@ module Likeno
 
     def destroy
       without_request_error? do
-        response = self.class.request(destroy_action, destroy_params, :delete, destroy_prefix)
+        response = self.class.request(destroy_action, destroy_params, :delete, destroy_prefix, destroy_headers)
         @persisted = false
       end
     end

--- a/lib/likeno/entity.rb
+++ b/lib/likeno/entity.rb
@@ -92,11 +92,11 @@ module Likeno
     end
 
     def self.exists?(id)
-      request(exists_action, id_params(id), :get)['exists']
+      request(exists_action, id_params(id), :get, exists_prefix, exists_headers)['exists']
     end
 
     def self.find(id)
-      response = request(find_action, id_params(id), :get)
+      response = request(find_action, id_params(id), :get, find_prefix, find_headers)
       new(response[entity_name], true)
     end
 

--- a/lib/likeno/helpers/crud_request_parameters.rb
+++ b/lib/likeno/helpers/crud_request_parameters.rb
@@ -48,6 +48,13 @@ module Likeno
       ''
     end
 
+    def default_headers
+      {}
+    end
+    alias_method :save_headers, :default_headers
+    alias_method :destroy_headers, :default_headers
+    alias_method :update_headers, :default_headers
+
     module ClassMethods
       def exists_action
         ':id/exists'

--- a/lib/likeno/helpers/crud_request_parameters.rb
+++ b/lib/likeno/helpers/crud_request_parameters.rb
@@ -67,6 +67,17 @@ module Likeno
       def find_action
         ':id'
       end
+
+      def find_prefix
+        ''
+      end
+      alias_method :exists_prefix, :find_prefix
+
+      def default_headers
+        {}
+      end
+      alias_method :find_headers, :default_headers
+      alias_method :exists_headers, :default_headers
     end
   end
 end

--- a/spec/likeno/entity_spec.rb
+++ b/spec/likeno/entity_spec.rb
@@ -70,7 +70,7 @@ describe Likeno::Entity do
 
     context 'when a record does not exist with given id' do
       before :each do
-        subject.class.expects(:request).with(url, params, http_method, '')
+        subject.class.expects(:request).with(url, params, http_method, '', {})
           .raises(Likeno::Errors::RecordNotFound)
       end
 
@@ -83,7 +83,7 @@ describe Likeno::Entity do
       before :each do
         error = Likeno::Errors::RequestError.new(response: mock(status: 500))
 
-        subject.class.expects(:request).with(url, params, http_method, '').raises(error)
+        subject.class.expects(:request).with(url, params, http_method, '', {}).raises(error)
       end
 
       it 'is expected to raise a RequestError error' do
@@ -95,7 +95,7 @@ describe Likeno::Entity do
       before :each do
         error = Likeno::Errors::RequestError.new(response: mock(status: 422, body: { 'errors' => errors }))
 
-        subject.class.expects(:request).with(url, params, http_method, '').raises(error)
+        subject.class.expects(:request).with(url, params, http_method, '', {}).raises(error)
       end
 
       context 'with a single error' do
@@ -140,7 +140,7 @@ describe Likeno::Entity do
       context 'when it is not persisted' do
         before :each do
           subject.expects(:instance_entity_name).at_least_once.returns('entity')
-          subject.class.expects(:request).at_least_once.with('', anything, :post, '')
+          subject.class.expects(:request).at_least_once.with('', anything, :post, '', {})
             .returns('entity' => { 'id' => 42, 'errors' => [] })
         end
 
@@ -176,7 +176,7 @@ describe Likeno::Entity do
         id = 42
 
         subject.expects(:id).at_least_once.returns(id)
-        described_class.expects(:request).with(':id', has_entry(id: id), :put, '')
+        described_class.expects(:request).with(':id', has_entry(id: id), :put, '', {})
           .returns('entity' => { 'id' => id, 'errors' => [] })
       end
 
@@ -203,11 +203,11 @@ describe Likeno::Entity do
   describe 'find' do
     context 'with an inexistent id' do
       before :each do
-        subject.class.expects(:request).at_least_once.with(':id', has_entry(id: 0), :get)
+        subject.class.expects(:request).at_least_once.with(':id', has_entry(id: 0), :get, '', {})
           .raises(Likeno::Errors::RecordNotFound)
       end
 
-      it 'is expected to raise a RecordNotFound error' do
+      xit 'is expected to raise a RecordNotFound error' do
         expect { subject.class.find(0) }.to raise_error(Likeno::Errors::RecordNotFound)
       end
     end
@@ -215,11 +215,11 @@ describe Likeno::Entity do
     context 'with an existent id' do
       before :each do
         subject.class.expects(:entity_name).at_least_once.returns('entity')
-        subject.class.expects(:request).with(':id', has_entry(id: 42), :get)
+        subject.class.expects(:request).with(':id', has_entry(id: 42), :get, '', {})
           .returns('entity' => { 'id' => 42 })
       end
 
-      it 'is expected to return an empty model' do
+      xit 'is expected to return an empty model' do
         expect(subject.class.find(42).id).to eq(42)
       end
     end
@@ -231,7 +231,7 @@ describe Likeno::Entity do
     context 'when it gets successfully destroyed' do
       before :each do
         subject.expects(:id).at_least_once.returns(42)
-        described_class.expects(:request).with(':id', { id: subject.id }, :delete, '').returns({})
+        described_class.expects(:request).with(':id', { id: subject.id }, :delete, '', {}).returns({})
       end
 
       it 'is expected to remain with the errors array empty and not persisted' do
@@ -295,11 +295,11 @@ describe Likeno::Entity do
       before :each do
         described_class
           .expects(:request)
-          .with(':id/exists', { id: 0 }, :get)
+          .with(':id/exists', { id: 0 }, :get, '', {})
           .returns('exists' => false)
       end
 
-      it 'is expected to return false' do
+      xit 'is expected to return false' do
         expect(described_class.exists?(0)).to eq(false)
       end
     end
@@ -308,11 +308,11 @@ describe Likeno::Entity do
       before :each do
         described_class
           .expects(:request)
-          .with(':id/exists', { id: 42 }, :get)
+          .with(':id/exists', { id: 42 }, :get, '', {})
           .returns('exists' => true)
       end
 
-      it 'is expected to return false' do
+      xit 'is expected to return false' do
         expect(described_class.exists?(42)).to eq(true)
       end
     end

--- a/spec/likeno/entity_spec.rb
+++ b/spec/likeno/entity_spec.rb
@@ -207,7 +207,7 @@ describe Likeno::Entity do
           .raises(Likeno::Errors::RecordNotFound)
       end
 
-      xit 'is expected to raise a RecordNotFound error' do
+      it 'is expected to raise a RecordNotFound error' do
         expect { subject.class.find(0) }.to raise_error(Likeno::Errors::RecordNotFound)
       end
     end
@@ -219,7 +219,7 @@ describe Likeno::Entity do
           .returns('entity' => { 'id' => 42 })
       end
 
-      xit 'is expected to return an empty model' do
+      it 'is expected to return an empty model' do
         expect(subject.class.find(42).id).to eq(42)
       end
     end
@@ -299,7 +299,7 @@ describe Likeno::Entity do
           .returns('exists' => false)
       end
 
-      xit 'is expected to return false' do
+      it 'is expected to return false' do
         expect(described_class.exists?(0)).to eq(false)
       end
     end
@@ -312,7 +312,7 @@ describe Likeno::Entity do
           .returns('exists' => true)
       end
 
-      xit 'is expected to return false' do
+      it 'is expected to return false' do
         expect(described_class.exists?(42)).to eq(true)
       end
     end


### PR DESCRIPTION
This adds support for including headers on CRUD requests.
It also adds the missing functionality of custom prefixes and headers for `exists` and `find`.
