### PR TITLE
Generalize hash conversion

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,8 @@ Likeno is a library for remote data model access over HTTP
 
 == Unreleased
 
+* Generalize Hash conversion for non Likeno::Entity instances
+
 == v1.0.1 - 23/03/2016
 
 * Fix hash conversion

--- a/lib/likeno/helpers/hash_converters.rb
+++ b/lib/likeno/helpers/hash_converters.rb
@@ -25,7 +25,7 @@ module Likeno
     def convert_to_hash(value)
       return value if value.nil?
       return value.collect { |element| convert_to_hash(element) } if value.is_a? Array
-      return value.to_hash if value.is_a?(Likeno::Entity)
+      return value.to_hash if value.respond_to?(:to_hash)
       return date_time_to_s(value) if value.is_a? DateTime
       return 'INF' if value.is_a?(Float) && value.infinite? == 1
       return '-INF' if value.is_a?(Float) && value.infinite? == -1

--- a/spec/likeno/helpers/hash_converters_spec.rb
+++ b/spec/likeno/helpers/hash_converters_spec.rb
@@ -18,6 +18,14 @@ require 'likeno/helpers/hash_converters'
 
 include Likeno::HashConverters
 
+class Another
+  attr_accessor :attr
+
+  def to_hash
+    {'attr' => self.attr}
+  end
+end
+
 describe Likeno::HashConverters do
   describe 'date_time_to_s' do
     context 'with 21/12/1995 (first Ruby publication)' do
@@ -72,6 +80,18 @@ describe Likeno::HashConverters do
     context 'with a negative infinite Float' do
       it 'returns -INF' do
         expect(convert_to_hash(-1.0 / 0.0)).to eq('-INF')
+      end
+    end
+
+    context 'without a base class that responds to to_hash' do
+      let(:obj) { Another.new }
+
+      before do
+        obj.attr = "attribute"
+      end
+
+      it 'is expected to do the conversion' do
+        expect(convert_to_hash(obj)).to eq({'attr' => obj.attr})
       end
     end
   end


### PR DESCRIPTION
Before it called to_hash just for Likeno::Entity instances. This was too
strict and was relaxed to check if the object responds to the method.

This should improve compatibility with other applications avoiding
overring by them.

Signed off by: Diego Araújo diegoamc@protonmail.ch
