### PR TITLE
Enable Travis build against older rubies and cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.3.0
+  - 2.0.0-p598 # CentOS 7
+  - 2.1.5 # Debian 8
 before_install: gem install bundler -v 1.10.6


### PR DESCRIPTION
The first ensures compatibility with target linux distros CentOS 7 and
Debian 8.

The second may speed up future builds.

this is part of https://github.com/mezuro/prezento/issues/350
