### PR TITLE
Fix old rubies support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Likeno is a library for remote data model access over HTTP
 
 ## Unreleased
 
+* Restrict to compatibility to activesupport previous to version 5
+
 ## v1.1.0 - 23/03/2016
 
 * Generalize Hash conversion for non Likeno::Entity instances

--- a/likeno.gemspec
+++ b/likeno.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter'
 
   spec.add_dependency 'faraday_middleware'
-  spec.add_dependency 'activesupport', '>= 2.2.1'
+  spec.add_dependency 'activesupport', '>= 2.2.1', '< 5'
 end


### PR DESCRIPTION
Activesupport 5 drops that, so we ensure bundler do not try to install
it.

Please notice the target branch is `v1`.
