### PR TITLE
Drop Ruby older than 2.2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ language: ruby
 cache: bundler
 rvm:
   - 2.3.0
-  - 2.0.0-p598 # CentOS 7
-  - 2.1.5 # Debian 8
 before_install: gem install bundler -v 1.10.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Likeno is a library for remote data model access over HTTP
 
 ## Unreleased
 
+* Drop Ruby older than 2.2.2 support
+
 ## v1.1.0 - 23/03/2016
 
 * Generalize Hash conversion for non Likeno::Entity instances

--- a/likeno.gemspec
+++ b/likeno.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.2.2'
+
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 11.1'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
This is the same version Rails 5 has locked to.
